### PR TITLE
remove useless secure_camera declaration in s7 and s7edge

### DIFF
--- a/arch/arm64/boot/dts/exynos8890-hero2lte_eur_open_04.dts
+++ b/arch/arm64/boot/dts/exynos8890-hero2lte_eur_open_04.dts
@@ -7976,13 +7976,6 @@
 			id = <0xa>;
 		};
 
-		secure_camera {
-			compatible = "exynos8890-ion,secure_camera";
-			secure;
-			reg = <0x0 0xfc000000 0x1c00000>;
-			id = <0xb>;
-		};
-
 		modem_if@0xF0000000 {
 			compatible = "exynos,modem_if";
 			reg = <0x0 0xf0000000 0x8800000>;

--- a/arch/arm64/boot/dts/exynos8890-hero2lte_eur_open_08.dts
+++ b/arch/arm64/boot/dts/exynos8890-hero2lte_eur_open_08.dts
@@ -7996,13 +7996,6 @@
 			id = <0xa>;
 		};
 
-		secure_camera {
-			compatible = "exynos8890-ion,secure_camera";
-			secure;
-			reg = <0x0 0xfc000000 0x1c00000>;
-			id = <0xb>;
-		};
-
 		modem_if@0xF0000000 {
 			compatible = "exynos,modem_if";
 			reg = <0x0 0xf0000000 0x8800000>;

--- a/arch/arm64/boot/dts/exynos8890-herolte_eur_open_04.dts
+++ b/arch/arm64/boot/dts/exynos8890-herolte_eur_open_04.dts
@@ -8011,13 +8011,6 @@
 			id = <0xa>;
 		};
 
-		secure_camera {
-			compatible = "exynos8890-ion,secure_camera";
-			secure;
-			reg = <0x0 0xfc000000 0x1c00000>;
-			id = <0xb>;
-		};
-
 		modem_if@0xF0000000 {
 			compatible = "exynos,modem_if";
 			reg = <0x0 0xf0000000 0x8800000>;

--- a/arch/arm64/boot/dts/exynos8890-herolte_eur_open_08.dts
+++ b/arch/arm64/boot/dts/exynos8890-herolte_eur_open_08.dts
@@ -8031,13 +8031,6 @@
 			id = <0xa>;
 		};
 
-		secure_camera {
-			compatible = "exynos8890-ion,secure_camera";
-			secure;
-			reg = <0x0 0xfc000000 0x1c00000>;
-			id = <0xb>;
-		};
-
 		modem_if@0xF0000000 {
 			compatible = "exynos,modem_if";
 			reg = <0x0 0xf0000000 0x8800000>;

--- a/arch/arm64/boot/dts/exynos8890-herolte_eur_open_09.dts
+++ b/arch/arm64/boot/dts/exynos8890-herolte_eur_open_09.dts
@@ -8030,13 +8030,6 @@
 			id = <0xa>;
 		};
 
-		secure_camera {
-			compatible = "exynos8890-ion,secure_camera";
-			secure;
-			reg = <0x0 0xfc000000 0x1c00000>;
-			id = <0xb>;
-		};
-
 		modem_if@0xF0000000 {
 			compatible = "exynos,modem_if";
 			reg = <0x0 0xf0000000 0x8800000>;

--- a/arch/arm64/boot/dts/exynos8890-herolte_eur_open_10.dts
+++ b/arch/arm64/boot/dts/exynos8890-herolte_eur_open_10.dts
@@ -8030,13 +8030,6 @@
 			id = <0xa>;
 		};
 
-		secure_camera {
-			compatible = "exynos8890-ion,secure_camera";
-			secure;
-			reg = <0x0 0xfc000000 0x1c00000>;
-			id = <0xb>;
-		};
-
 		modem_if@0xF0000000 {
 			compatible = "exynos,modem_if";
 			reg = <0x0 0xf0000000 0x8800000>;

--- a/drivers/staging/android/ion/exynos/exynos_ion.c
+++ b/drivers/staging/android/ion/exynos/exynos_ion.c
@@ -359,7 +359,6 @@ DECLARE_EXYNOS_ION_RESERVED_REGION("exynos8890-ion,", vscaler);
 DECLARE_EXYNOS_ION_RESERVED_REGION("exynos8890-ion,", gpu_crc);
 DECLARE_EXYNOS_ION_RESERVED_REGION("exynos8890-ion,", gpu_buffer);
 DECLARE_EXYNOS_ION_RESERVED_REGION("exynos8890-ion,", camera);
-DECLARE_EXYNOS_ION_RESERVED_REGION("exynos8890-ion,", secure_camera);
 
 int ion_exynos_contig_heap_info(int region_id, phys_addr_t *phys, size_t *size)
 {


### PR DESCRIPTION
secure_camera refers to iris camera of Note 7 and Note FE.
it does not exist in s7 and s7edge.
So we should remove it from device tree and ion drivers, otherwise it would carve out 28 MB  memory and reduce the amount of memory that normal application could occupy.